### PR TITLE
A few usability improvments and a bugfix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "Formatters"
   ],
   "activationEvents": [
-    "onCommand:swagger-jsdoc-indent.format"
+    "onCommand:swagger-jsdoc-indent.format",
+    "onCommand:swagger-jsdoc-indent.unformat"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -23,6 +24,10 @@
       {
         "command": "swagger-jsdoc-indent.format",
         "title": "Format swagger-jsdoc comment"
+      },
+      {
+        "command": "swagger-jsdoc-indent.unformat",
+        "title": "Unformat swagger-jsdoc comment"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { formatSwagger } from "./utils";
+import { formatSwagger, unFormatSwagger } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
-  let disposable = vscode.commands.registerCommand(
+  context.subscriptions.push(vscode.commands.registerCommand(
     "swagger-jsdoc-indent.format",
     () => {
       const editor = vscode.window.activeTextEditor;
@@ -36,10 +36,45 @@ export function activate(context: vscode.ExtensionContext) {
         );
         return;
       }
-    }
+    })
   );
 
-  context.subscriptions.push(disposable);
+  context.subscriptions.push(vscode.commands.registerCommand(
+    "swagger-jsdoc-indent.unformat",
+    () => {
+      const editor = vscode.window.activeTextEditor;
+
+      if (editor) {
+        const selection = editor.selection;
+        const text = editor.document.getText(selection);
+
+        if (!text) {
+          vscode.window.showErrorMessage(
+            "Please select a swagger-jsdoc comment"
+          );
+          return;
+        }
+
+        const formatted = unFormatSwagger(text);
+
+        if (!formatted) {
+          vscode.window.showErrorMessage(
+            "An error occurred while unformatting your comment"
+          );
+          return;
+        }
+
+        editor.edit((e) => {
+          e.replace(selection, formatted);
+        });
+      } else {
+        vscode.window.showWarningMessage(
+          "Please open a file with swagger comments in it"
+        );
+        return;
+      }
+    })
+  );
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,54 @@
 import * as vscode from "vscode";
 import { formatSwagger, unFormatSwagger } from "./utils";
 
+
+function findBackward(text: string, index: number): number {
+  const bracketStack: string[] = [];
+  for (let i = index; i >= 1; i--) {
+      let char1 = text.charAt(i);
+      let char2 = text.charAt(i-1);
+      if(char1==="*" && char2==="/") {
+        return i-1;
+      }
+  }
+  //we are geting to the edge
+  return -1;
+}
+
+function findForward(text: string, index: number): number {
+  const bracketStack: string[] = [];
+  for (let i = index; i < text.length-1; i++) {
+      let char1 = text.charAt(i);
+      let char2 = text.charAt(i+1);
+      if(char1==="*" && char2==="/") {
+        return i+1;
+      }
+  }
+  //we are geting to the edge
+  return -1;
+}
+
+function findSelection(selection: vscode.Selection): vscode.Selection {
+  
+  const editor = vscode.window.activeTextEditor;
+  if(!editor) return selection;
+
+  let selectionStart = editor.document.offsetAt(selection.start)-1;
+  let selectionEnd = editor.document.offsetAt(selection.end);
+  let text = editor.document.getText();
+
+  var backwardIndex = findBackward(text, selectionStart);
+  var forwardIndex = findForward(text, selectionEnd);
+
+  if(backwardIndex!==-1 && forwardIndex!==-1) {
+    return new vscode.Selection(
+      editor.document.positionAt(backwardIndex - 1), //convert text index to vs selection index
+      editor.document.positionAt(forwardIndex + 1)
+  );
+  }
+  return selection;
+}
+
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(
     "swagger-jsdoc-indent.format",
@@ -8,7 +56,8 @@ export function activate(context: vscode.ExtensionContext) {
       const editor = vscode.window.activeTextEditor;
 
       if (editor) {
-        const selection = editor.selection;
+        const selection = findSelection(editor.selection);
+        
         const text = editor.document.getText(selection);
 
         if (!text) {
@@ -45,7 +94,7 @@ export function activate(context: vscode.ExtensionContext) {
       const editor = vscode.window.activeTextEditor;
 
       if (editor) {
-        const selection = editor.selection;
+        const selection = findSelection(editor.selection);
         const text = editor.document.getText(selection);
 
         if (!text) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,3 +57,51 @@ export const formatSwagger = (comment: string) => {
     console.log(error);
   }
 };
+
+export const unFormatSwagger = (comment: string) => {
+  /**
+   * Strip swagger spec.
+   *
+   * Captures all text between @swagger | @openapi and  `*\/`
+   * which is the swagger spec.
+   */
+  let match = comment.match(
+    / \* (?<tag>@swagger\s|@openapi\s)(?<spec>[\s\S]+?)(?=^.*\*\/+)/m
+  );
+
+  if (
+    !match ||
+    !match.groups ||
+    !("tag" in match.groups) ||
+    !("spec" in match.groups)
+  ) {
+    return;
+  }
+
+  let { spec, tag }: { tag: string; spec: string } = match.groups as {
+    tag: string;
+    spec: string;
+  };
+
+  try {
+    spec = spec
+      .split("\n")
+      .map((e) => {
+        let match=e.match(/ \* (.*)$/);
+        if(!match) { 
+          return e
+        }
+        else {
+          return match[1];
+        }
+      })
+      .join("\n");
+
+    spec = tag + spec;
+
+    return comment.replace(match[0], spec);
+  } catch (error) {
+    vscode.window.showErrorMessage(error.message);
+    console.log(error);
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export const formatSwagger = (comment: string) => {
    * which is the swagger spec.
    */
   let match = comment.match(
-    /(?<tag>@swagger\s|@openapi\s)(?<spec>[\s\S]+?)(?=^.*\*\/*)/m
+    /(?<tag>@swagger\s|@openapi\s)(?<spec>[\s\S]+?)(?=^.*\*\/+)/m
   );
 
   if (


### PR DESCRIPTION
Sometimes I have **Bold Text** embedded in my swagger/openapi descriptions.  This fixes the regular expression to ignore the double asterisk.  Also added the "unformat" command to easily remove the leading " * " so the openapi can be edited then re-encoded.  Finally, it will now auto-select the whole comment when running the format/unformat.